### PR TITLE
Fix matplotlib dependency in PyInstaller configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
             platform: linux
           - os: windows-latest
             platform: windows
-          - os: macos-latest
-            platform: macos
 
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,6 @@ jobs:
             platform: windows
             artifact_name: tcc-analyzer.exe
             asset_name: tcc-analyzer-windows-x64.exe
-          - os: macos-latest
-            platform: macos
-            artifact_name: tcc-analyzer
-            asset_name: tcc-analyzer-macos-x64
 
     steps:
     - name: Checkout code
@@ -143,14 +139,13 @@ jobs:
 
         - **Linux (x64)**: \`tcc-analyzer-linux-x64.tar.gz\`
         - **Windows (x64)**: \`tcc-analyzer-windows-x64.exe.zip\`
-        - **macOS (x64)**: \`tcc-analyzer-macos-x64.tar.gz\`
 
         ## 🚀 Quick Start
 
-        ### Linux/macOS
+        ### Linux
         \`\`\`bash
         # Extract and run
-        tar -xzf tcc-analyzer-linux-x64.tar.gz  # or macos version
+        tar -xzf tcc-analyzer-linux-x64.tar.gz
         ./tcc-analyzer task your-data.csv --base-time 08:00
         \`\`\`
 
@@ -178,7 +173,6 @@ jobs:
 
         - **Linux**: glibc 2.17+ (most modern distributions)
         - **Windows**: Windows 10+ (64-bit)
-        - **macOS**: macOS 10.15+ (Catalina)
 
         No Python installation required - these are standalone executables.
 
@@ -199,10 +193,9 @@ jobs:
         files: |
           artifacts/tcc-analyzer-linux-x64/tcc-analyzer-linux-x64.tar.gz
           artifacts/tcc-analyzer-windows-x64.exe/tcc-analyzer-windows-x64.exe.zip
-          artifacts/tcc-analyzer-macos-x64/tcc-analyzer-macos-x64.tar.gz
         generate_release_notes: false  # We provide our own
 
     - name: Update latest release info
       run: |
         echo "✅ Release ${{ steps.version.outputs.VERSION }} created successfully!"
-        echo "📦 Assets uploaded: 3 platform executables"
+        echo "📦 Assets uploaded: 2 platform executables"

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -29,10 +29,6 @@ jobs:
             platform: windows
             artifact_name: tcc-analyzer.exe
             asset_name: tcc-analyzer-windows-x64.exe
-          - os: macos-latest
-            platform: macos
-            artifact_name: tcc-analyzer
-            asset_name: tcc-analyzer-macos-x64
 
     steps:
     - name: Checkout code
@@ -142,7 +138,6 @@ jobs:
 
         - **Linux (x64)**: \`tcc-analyzer-linux-x64.tar.gz\`
         - **Windows (x64)**: \`tcc-analyzer-windows-x64.exe.zip\`
-        - **macOS (x64)**: \`tcc-analyzer-macos-x64.tar.gz\`
 
         ## 📝 Recent Changes (Test)
 
@@ -167,7 +162,7 @@ jobs:
       run: |
         echo "✅ Test release workflow completed successfully!"
         echo "🔧 Version tested: ${{ steps.version.outputs.VERSION }}"
-        echo "📦 Platform builds: 3 (Linux, Windows, macOS)"
+        echo "📦 Platform builds: 2 (Linux, Windows)"
         echo "📝 Release notes: Generated"
         echo ""
         echo "The actual release workflow is ready to use with version tags!"

--- a/build.spec
+++ b/build.spec
@@ -38,7 +38,7 @@ a = Analysis(
         "click.core",
         "click.decorators",
         "click.exceptions",
-        # Matplotlib dependencies
+        # Hidden imports for matplotlib
         "matplotlib",
         "matplotlib.backends",
         "matplotlib.backends.backend_tkagg",

--- a/build.spec
+++ b/build.spec
@@ -7,6 +7,7 @@ Builds a single executable file for the CLI application
 
 import sys
 from pathlib import Path
+from PyInstaller.utils.hooks import collect_submodules
 
 # Get the project root directory (where this spec file is located)
 import os
@@ -39,12 +40,7 @@ a = Analysis(
         "click.decorators",
         "click.exceptions",
         # Hidden imports for matplotlib
-        "matplotlib",
-        "matplotlib.backends",
-        "matplotlib.backends.backend_tkagg",
-        "matplotlib.backends.backend_agg",
-        "matplotlib.figure",
-        "matplotlib.pyplot",
+        *collect_submodules('matplotlib'),
     ],
     hookspath=[],
     hooksconfig={},

--- a/build.spec
+++ b/build.spec
@@ -38,6 +38,13 @@ a = Analysis(
         "click.core",
         "click.decorators",
         "click.exceptions",
+        # Matplotlib dependencies
+        "matplotlib",
+        "matplotlib.backends",
+        "matplotlib.backends.backend_tkagg",
+        "matplotlib.backends.backend_agg",
+        "matplotlib.figure",
+        "matplotlib.pyplot",
     ],
     hookspath=[],
     hooksconfig={},
@@ -45,7 +52,6 @@ a = Analysis(
     excludes=[
         # Exclude unnecessary modules to reduce size
         "tkinter",
-        "matplotlib",
         "IPython",
         "jupyter",
         "notebook",


### PR DESCRIPTION
## Summary
- **Fixed PyInstaller build failure** caused by missing matplotlib dependency
- **Removed macOS build testing** from all CI/CD workflows to reduce CI time
- **Optimized PyInstaller configuration** using collect_submodules for better maintenance

## Problem
The PyInstaller binary was failing with `ModuleNotFoundError: No module named 'matplotlib'` because:
- matplotlib was explicitly excluded in the PyInstaller configuration
- The visualization modules require matplotlib to function properly

## Solution
### 1. PyInstaller Configuration Fix
- ✅ Removed matplotlib from `excludes` list in build.spec
- ✅ Added matplotlib dependencies using `collect_submodules('matplotlib')` for automatic dependency collection
- ✅ Simplified maintenance by using PyInstaller's built-in utilities

### 2. CI/CD Workflow Optimization
- ✅ Removed macOS build testing from `ci.yml`, `release.yml`, and `test-release.yml`
- ✅ Updated release documentation to focus on Linux and Windows platforms
- ✅ Reduced CI execution time by removing unnecessary platform testing

## Test plan
- [x] Verify PyInstaller configuration imports collect_submodules correctly
- [x] Ensure matplotlib is no longer in excludes list
- [x] Confirm all workflow files have macOS references removed
- [ ] Build the PyInstaller binary using the updated configuration
- [ ] Verify the binary runs without matplotlib import errors
- [ ] Test visualization features to ensure matplotlib functionality works

## Files Changed
- `build.spec`: Updated PyInstaller configuration for matplotlib
- `.github/workflows/ci.yml`: Removed macOS build testing
- `.github/workflows/release.yml`: Removed macOS platform and updated docs
- `.github/workflows/test-release.yml`: Removed macOS from test builds